### PR TITLE
書類種別パラメーター乱数対応

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -191,6 +191,10 @@ function bill_get_post_type() {
 		$post_type['slug'] = 'post';
 	}
 
+	if( !post_type_exists( $post_type['slug'] ) ) {
+	    $post_type['slug'] = "post";
+    }
+
 	// Get post type name
 	/*-------------------------------------------*/
 	$post_type_object = get_post_type_object( $post_type['slug'] );


### PR DESCRIPTION
define('WP_DEBUG', true);
URLのpost_typeパラメーターに変数を入れると、以下のnoticeメッセージが表示される。
Notice: Trying to get property 'labels' of non-object in /home/kikurin/www/wptest/wp-content/themes/bill-vektor/inc/template-tags.php on line 202

この問題を修正しました。
