### PR TITLE
【確認待ち】領収書のtitle要素のフォーマットを変更

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -209,7 +209,7 @@ add_filter( 'register_post_type_args', 'bill_change_post_type_args_post' );
 -------------------------------------------
 */
 function bill_title_custom( $title ) {
-	$target_post_types = array( 'post', 'estimate' );
+	$target_post_types = array( 'post', 'estimate' , 'receipt' );
 
 	if ( is_single() ) {
 		global $post;


### PR DESCRIPTION
PDF出力時のフォーマット（つまりtitleタグの中身のフォーマット）が、領収書のみ異なるのを修正。