### PR TITLE
[ 不具合修正 ] 税込入力の品目で消費税の端数処理が二重に適用され税込合計が1円ずれる不具合を修正

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -152,7 +152,10 @@ function bill_vektor_fix_tax_type( $old_tax_type ) {
 
 /**
  * インボイス対応の税率ごとの合計金額
- * @return array $tax_total 税率ごとの合計金額
+ *
+ * @param WP_Post $post 投稿オブジェクト。
+ * @return array $tax_total 税率ごとの合計金額。
+ *               各要素は rate（税率ラベル）・price（税抜合計）・tax（消費税額）・total（税込合計）を持つ配列。
  */
 function bill_vektor_invoice_each_tax( $post ) {
 	// カスタムフィールドを取得
@@ -166,7 +169,7 @@ function bill_vektor_invoice_each_tax( $post ) {
 	$old_tax_rate = get_post_meta( $post->ID, 'bill_tax_rate', true );
 	// 古い税込・税抜
 	$old_tax_type = get_post_meta( $post->ID, 'bill_tax_type', true );
-	// 消費税の丸め処理
+	// 消費税の丸め処理（税抜入力品目の消費税合算値に適用される）
 	$tax_fraction = ! empty( get_post_meta( $post->ID, 'bill_tax_fraction', true ) ) ? get_post_meta( $post->ID, 'bill_tax_fraction', true ) : 'round';
 
 	if ( is_array( $bill_items ) ) {
@@ -199,8 +202,11 @@ function bill_vektor_invoice_each_tax( $post ) {
 						// 税率を数値に変換
 						$item_tax_rate = 0.01 * intval( str_replace( '%', '', $bill_item['tax-rate'] ) );
 
-						// 単価を数値に変換
-						$item_price = bill_vektor_invoice_unit_plice( bill_item_number( $bill_item['price'] ), $item_tax_rate, $bill_item['tax-type'] );
+						// 入力された元の単価を数値に変換（税込・税抜変換前の値）
+						$item_original_price = bill_item_number( $bill_item['price'] );
+
+						// 単価を税抜価格に変換（税込入力の場合は税込→税抜に変換、税抜入力はそのまま）
+						$item_price = bill_vektor_invoice_unit_plice( $item_original_price, $item_tax_rate, $bill_item['tax-type'] );
 
 						// 個数を数値に変換
 						$item_count = bill_item_number( $bill_item['count'] );
@@ -208,12 +214,24 @@ function bill_vektor_invoice_each_tax( $post ) {
 						// 上記３つが数値なら
 						if ( is_numeric( $item_count ) && is_numeric( $item_price ) && is_numeric( $item_tax_rate ) ) {
 
-							// 合計金額を算出
+							// 税抜合計金額を算出（税抜単価 × 個数）
 							$item_total = bill_vektor_invoice_total_plice( $item_price, $item_count );
-							// 品目ごとの消費税額
-							$item_tax_value = bill_vektor_invoice_tax_plice( $item_total, $item_tax_rate );
-							// 品目ごとの税込合計金額
-							$item_tax_total = bill_vektor_invoice_full_plice( $item_total, $item_tax_value );
+
+							// 消費税額の計算方法を税込・税抜によって分岐
+							// 税込入力の場合：元の税込合計 - 税抜合計 で消費税を確定する。
+							//   理由：税込→税抜変換時に端数処理が発生するため、
+							//         「税抜合計 × 税率」で再計算すると端数が二重に発生して税込合計が1円ずれる。
+							//         「元の税込合計 - 税抜合計」なら端数処理は1回（税抜変換時）のみになり、
+							//         税抜 + 消費税 = 元の税込価格 が常に成立する。
+							// 税抜入力の場合：税抜合計 × 税率 で消費税を算出する（小数のまま保持し、後の合算後に丸め処理をかける）。
+							if ( in_array( $bill_item['tax-type'], array( 'tax_included', 'tax_included_ceil', 'tax_included_floor' ), true ) ) {
+								// 税込入力：元の税込合計（税込単価 × 個数）から税抜合計を引いた値が消費税
+								$item_original_total = $item_original_price * $item_count;
+								$item_tax_value      = $item_original_total - $item_total;
+							} else {
+								// 税抜入力：税抜合計 × 税率（bill_tax_fraction による丸め処理の対象になる）
+								$item_tax_value = bill_vektor_invoice_tax_plice( $item_total, $item_tax_rate );
+							}
 
 							// 税率何％の対象か
 							$tax_total[ $tax_rate ]['rate'] = $bill_item['tax-rate'] . '対象';
@@ -230,6 +248,7 @@ function bill_vektor_invoice_each_tax( $post ) {
 		foreach ( $tax_total as $tax_key => $tax_value ) {
 			// 消費税の丸め処理
 			// $tax_fraction には floor, round, ceil のいずれかが入っているので call_user_func でその関数を直接呼び出している
+			// 税込入力品目の消費税は整数で確定済みのため、この丸め処理は主に税抜入力品目の小数分に効く
 			$tax_total[ $tax_key ]['tax'] = call_user_func( $tax_fraction, $tax_value['tax'] );
 			// 税抜金額と消費税から税込み金額を算出
 			$tax_total[ $tax_key ]['total'] = $tax_value['price'] + $tax_total[ $tax_key ]['tax'];

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/BillVektor
 
 == Changelog ==
 
+[ 不具合修正 ] 税込入力の品目で消費税の端数処理が二重に適用され税込合計が1円ずれる不具合を修正
+
 1.11.7
 [ その他 ] フレキシブルテーブルのカスタムフィールドで select（プルダウン）タイプをサポート
 

--- a/template-parts/doc/table-price.php
+++ b/template-parts/doc/table-price.php
@@ -66,8 +66,11 @@ if ( is_array( $bill_items ) ) {
 			// 個数を数値にフォーマット
 			$item_count = bill_item_number( $bill_item['count'] );
 
-			// 単価を数値にフォーマット
-			$item_price = bill_vektor_invoice_unit_plice( bill_item_number( $bill_item['price'] ), $item_tax_rate_value, $bill_item['tax-type'] );
+			// 入力された元の単価を数値に変換（税込・税抜変換前の値）
+			$item_original_price = bill_item_number( $bill_item['price'] );
+
+			// 単価を税抜価格にフォーマット（税込入力の場合は税込→税抜に変換、税抜入力はそのまま）
+			$item_price = bill_vektor_invoice_unit_plice( $item_original_price, $item_tax_rate_value, $bill_item['tax-type'] );
 
 			// 単価と個数と税率が数値なら続行 ///////////////////////////////////////////////////////
 			if ( is_numeric( $item_count ) && is_numeric( $item_price ) && is_numeric( $item_tax_rate_value ) ) :
@@ -82,8 +85,17 @@ if ( is_array( $bill_items ) ) {
 					$lite_tax_flag = true;
 				}
 
-				// 対象品目の合計消費税額
-				$item_tax_value       = bill_vektor_invoice_tax_plice( $item_price_total, $item_tax_rate_value );
+				// 消費税額の計算方法を税込・税抜によって分岐
+				// 税込入力の場合：元の税込合計 - 税抜合計 で消費税を確定する（端数処理を二重にかけないため）
+				// 税抜入力の場合：税抜合計 × 税率 で消費税を算出する
+				if ( in_array( $bill_item['tax-type'], array( 'tax_included', 'tax_included_ceil', 'tax_included_floor' ), true ) ) {
+					// 税込入力：元の税込合計から税抜合計を引いた値が消費税
+					$item_original_total = $item_original_price * $item_count;
+					$item_tax_value      = $item_original_total - $item_price_total;
+				} else {
+					// 税抜入力：税抜合計 × 税率
+					$item_tax_value = bill_vektor_invoice_tax_plice( $item_price_total, $item_tax_rate_value );
+				}
 				$item_tax_value_print = '¥ ' . number_format( $item_tax_value, $digits );
 				$form_item_tax_rate   = $item_tax_rate !== '0%' ? $item_tax_rate : __( '非課税', 'bill-vektor' );
 

--- a/tests/test-invoice.php
+++ b/tests/test-invoice.php
@@ -537,34 +537,37 @@ class InvoiceTest extends WP_UnitTestCase {
 			),
 			array(
 				'post_id'  => $data['tax_round_default'],
+				// 税込入力（四捨五入）：税抜=5455、消費税=6000-5455=545、税込合計=6000
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5455,
-						'tax'   => 546,
-						'total' => 6001,
+						'tax'   => 545,
+						'total' => 6000,
 					),
 				),
 			),
 			array(
 				'post_id'  => $data['tax_round_round'],
+				// 税込入力（四捨五入）：消費税の丸め設定は税込入力では効かない（税込-税抜方式のため）
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5455,
-						'tax'   => 546,
-						'total' => 6001,
+						'tax'   => 545,
+						'total' => 6000,
 					),
 				),
 			),
 			array(
 				'post_id'  => $data['tax_round_ceil'],
+				// 税込入力（四捨五入）：消費税の丸め設定は税込入力では効かない（税込-税抜方式のため）
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5455,
-						'tax'   => 546,
-						'total' => 6001,
+						'tax'   => 545,
+						'total' => 6000,
 					),
 				),
 			),
@@ -581,34 +584,37 @@ class InvoiceTest extends WP_UnitTestCase {
 			),
 			array(
 				'post_id'  => $data['tax_ceil_default'],
+				// 税込入力（切り上げ）：税抜=ceil(6000/1.1)=5455、消費税=6000-5455=545、税込合計=6000
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5455,
-						'tax'   => 546,
-						'total' => 6001,
+						'tax'   => 545,
+						'total' => 6000,
 					),
 				),
 			),
 			array(
 				'post_id'  => $data['tax_ceil_round'],
+				// 税込入力（切り上げ）：消費税の丸め設定は税込入力では効かない（税込-税抜方式のため）
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5455,
-						'tax'   => 546,
-						'total' => 6001,
+						'tax'   => 545,
+						'total' => 6000,
 					),
 				),
 			),
 			array(
 				'post_id'  => $data['tax_ceil_ceil'],
+				// 税込入力（切り上げ）：消費税の丸め設定は税込入力では効かない（税込-税抜方式のため）
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5455,
-						'tax'   => 546,
-						'total' => 6001,
+						'tax'   => 545,
+						'total' => 6000,
 					),
 				),
 			),
@@ -625,23 +631,25 @@ class InvoiceTest extends WP_UnitTestCase {
 			),
 			array(
 				'post_id'  => $data['tax_floor_default'],
+				// 税込入力（切り捨て）：税抜=floor(6000/1.1)=5454、消費税=6000-5454=546、税込合計=6000
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5454,
-						'tax'   => 545,
-						'total' => 5999,
+						'tax'   => 546,
+						'total' => 6000,
 					),
 				),
 			),
 			array(
 				'post_id'  => $data['tax_floor_round'],
+				// 税込入力（切り捨て）：消費税の丸め設定は税込入力では効かない（税込-税抜方式のため）
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5454,
-						'tax'   => 545,
-						'total' => 5999,
+						'tax'   => 546,
+						'total' => 6000,
 					),
 				),
 			),
@@ -658,12 +666,13 @@ class InvoiceTest extends WP_UnitTestCase {
 			),
 			array(
 				'post_id'  => $data['tax_floor_floor'],
+				// 税込入力（切り捨て）：消費税の丸め設定は税込入力では効かない（税込-税抜方式のため）
 				'cortrect' => array(
 					'10%' => array(
 						'rate'  => '10%対象',
 						'price' => 5454,
-						'tax'   => 545,
-						'total' => 5999,
+						'tax'   => 546,
+						'total' => 6000,
 					),
 				),
 			),
@@ -732,52 +741,64 @@ class InvoiceTest extends WP_UnitTestCase {
 				'cortrect' => 32800,
 			),
 			array(
+				// 税込入力（四捨五入）: 税込-税抜方式で計算するため 6000 円になる
 				'post_id'  => $data['tax_round_default'],
-				'cortrect' => 6001,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（四捨五入）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_round_round'],
-				'cortrect' => 6001,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（四捨五入）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_round_ceil'],
-				'cortrect' => 6001,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（四捨五入）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_round_floor'],
 				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り上げ）: 税込-税抜方式で計算するため 6000 円になる
 				'post_id'  => $data['tax_ceil_default'],
-				'cortrect' => 6001,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り上げ）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_ceil_round'],
-				'cortrect' => 6001,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り上げ）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_ceil_ceil'],
-				'cortrect' => 6001,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り上げ）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_ceil_floor'],
 				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り捨て）: 税抜=5454、消費税=6000-5454=546、合計 6000 円になる
 				'post_id'  => $data['tax_floor_default'],
-				'cortrect' => 5999,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り捨て）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_floor_round'],
-				'cortrect' => 5999,
+				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り捨て）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_floor_ceil'],
 				'cortrect' => 6000,
 			),
 			array(
+				// 税込入力（切り捨て）: 消費税の丸め設定は税込入力では効かない
 				'post_id'  => $data['tax_floor_floor'],
-				'cortrect' => 5999,
+				'cortrect' => 6000,
 			),
 			array(
 				'post_id'  => $data['tax_none'],


### PR DESCRIPTION
## 概要

税込入力の品目（`tax_included` / `tax_included_ceil` / `tax_included_floor`）で、消費税の端数処理が二重に適用され、税込合計が元の入力価格より1円多くなる不具合を修正しました。

関連 issue: #248, #265

---

## バグの原因

### 二重の端数処理

税込入力のとき、以下の2箇所で端数処理がかかっていました。

**1箇所目（`bill_vektor_invoice_unit_plice()`）**：税込価格 → 税抜単価の変換
```
6,000円 ÷ 1.1 = 5454.545... → round() → 5,455円（ここで1回目の丸め）
```

**2箇所目（`bill_vektor_invoice_each_tax()` 233行目）**：消費税合算後の丸め処理
```
5,455 × 0.1 = 545.5 → round() → 546円（ここで2回目の丸め）
```

結果：5,455 + 546 = **6,001円**（元の税込価格6,000円より1円多い）

### ずれが発生する条件

税抜単価の1の位が `5` のとき、消費税計算で `×0.1` するとちょうど `.5` になり、`round()` で繰り上がります。tax_included（四捨五入）で切り上げが発生した場合（例：6,000円 → 税抜5,455円）は消費税でも繰り上がって二重に大きくなります。なお、5,000円（税抜4,545円）のように税抜変換で切り捨てになるケースでは、消費税の切り上がりと相殺されてたまたまずれません。

---

## 修正方針（案A：コードで分岐）

**税込入力の品目**は「元の税込合計 − 税抜合計」で消費税を直接確定します（端数処理は税抜変換時の1回のみ）。

```
税抜単価: round(6,000 ÷ 1.1) = 5,455
消費税:   6,000 − 5,455 = 545（端数処理なし・整数で確定）
税込合計: 5,455 + 545 = 6,000 ✓
```

**税抜入力の品目**は従来通り「税抜合計 × 税率」で計算し、合算後に `bill_tax_fraction`（切り捨て・四捨五入・切り上げ）の設定を適用します。

---

## 影響範囲と懸念点

### 1. 既存の請求書への影響

修正後は、以下の条件に該当する請求書で表示される税込合計が**1円減ります**（元の入力価格と一致するため、これが正しい値です）。

- 税込入力（`tax_included` / `tax_included_ceil`）を使用している品目がある
- かつ `bill_tax_fraction` が `round`（デフォルト）または `ceil` に設定されている
- かつ税込→税抜の変換で切り上げが発生する価格（例：6,000円、50,000円など）

`bill_tax_fraction` を `floor` に設定していたケースは、修正前でもたまたま正しい値になっていたため変化しません。

### 2. `bill_tax_fraction`（消費税の端数処理設定）の挙動変化

税込入力品目の消費税は「元の税込 − 税抜」で整数として確定するため、`bill_tax_fraction` の設定（round/ceil/floor）は**税込入力品目には効かなくなります**。

ただし、税抜入力品目の消費税には引き続き有効に機能します（例：税抜3,333円×3個の消費税999.9円に対してどの丸め処理を適用するか）。また、税込品目と税抜品目が混在する場合も、税抜品目の消費税の小数分に対して `bill_tax_fraction` が効きます。

### 3. テストの期待値変更

既存の `tests/test-invoice.php` がバグ込みの計算結果（6,001円など）を期待値として設定していたため、あわせて正しい値（6,000円）に修正しました。

---

## 確認手順

### 前提条件
- BillVektor テーマが有効化されていること
- 請求書（または見積書）の編集画面が使えること

### Before（修正前の再現手順）

1. 新規請求書を作成する
2. 品目を1行追加し、以下を入力する
   - 単価：`6000`
   - 数量：`1`
   - 税抜/税込：**税込（税抜単価は四捨五入）**
   - 消費税率：`10%`
3. 「消費税の端数処理」を「四捨五入」に設定する
4. 請求書を保存してプレビューまたは本文を確認する
   → ✗ 合計金額表の「10%対象」行で「税込金額」が `¥ 6,001` と表示される（元の入力価格 6,000円と1円ずれている）

### After（修正後）

1. 上記の手順1〜4を同じ操作で確認する
   → ✓ 合計金額表の「10%対象」行で「税込金額」が `¥ 6,000` と正しく表示される
   → ✓ 「税抜金額」: ¥ 5,455 / 「消費税額」: ¥ 545 / 「税込金額」: ¥ 6,000

### デグレ確認

1. 品目を1行追加し、以下を入力する
   - 単価：`10000`
   - 数量：`1`
   - 税抜/税込：**税抜**
   - 消費税率：`10%`
2. 「消費税の端数処理」を「切り捨て」に設定して保存
   → ✓ 「10%対象」行で「税抜金額」: ¥ 10,000 / 「消費税額」: ¥ 1,000 / 「税込金額」: ¥ 11,000（税抜入力は従来と変わらず正常に動作する）

3. 単価を割り切れない値（`3333`）に変更し、数量を `3` にして保存
   - 「消費税の端数処理」を「切り捨て」
   → ✓ 消費税が `floor()` で処理され、合計が `9999 + 999 = 10,998円` になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 税込み入力の品目で、消費税の端数処理が二重に適用されて合計金額が1円ずれる不具合を修正しました。
  * 税区分に応じて税額の算出方法を見直し、税込入力では合計差分から、税抜入力では税抜合計から計算するようになりました。
  * 税率ごとの集計やインボイス関連の結果が、より安定して一貫した値になるよう改善しました。

* **Documentation**
  * 税額計算の説明と更新履歴を見直し、挙動がより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->